### PR TITLE
Temporarily removed NPM Pixi dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
 	"name": "pixi-animate",
-	"version": "0.5.1",
+	"version": "0.5.2-alpha",
 	"main": "dist/pixi-animate.min.js",
 	"dependencies":
 	{

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,7 @@ const options = {
     pkg, pkg,
     lint: [src, 'tests/**/*.js', '!tests/renders/assets/*.js'],
     format: [src, 'tests/*.js', 'tasks/*.js'],
+    copy: ['node_modules/pixi.js/bin/*'],
     tests: 'tests',
     eslint: {
         extends: ['eslint:recommended'],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pixi-animate",
   "description": "PIXI plugin for the PixiAnimate Extension",
-  "version": "0.5.1",
+  "version": "0.5.2-alpha",
   "main": "dist/pixi-animate.min.js",
   "author": "Matt Karl <matt.karl@jibo.com>",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "dist/pixi-animate.min.js",
   "author": "Matt Karl <matt.karl@jibo.com>",
   "dependencies": {
-    "pixi.js": "https://github.com/jiborobot/pixi.js.git#dev",
     "loophole": "^1.1.0"
   },
   "devDependencies": {
+    "pixi.js": "https://github.com/jiborobot/pixi.js.git#dev",
     "babel-preset-es2015": "^6.6.0",
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -13,10 +13,10 @@ if (typeof module !== 'undefined' && module.exports) {
 
         // Include the Pixi.js module
         // @if DEBUG
-        require('pixi.js/bin/pixi.js');
+        require('./pixi.js');
         // @endif
         // @if RELEASE
-        require('pixi.js/bin/pixi.min.js');
+        require('./pixi.min.js');
         // @endif
     }
 

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -1,0 +1,8 @@
+"use strict";
+
+module.exports = function(gulp, options, plugins) {
+    gulp.task('copy', function() {
+        return gulp.src(options.copy)
+            .pipe(gulp.dest(options.dest));
+    });
+};

--- a/tasks/default.js
+++ b/tasks/default.js
@@ -8,6 +8,7 @@ module.exports = function(gulp, options, plugins) {
             'format',
             'build',
             'build-debug',
+            'copy',
             'test',
             done
         );


### PR DESCRIPTION
Remove pixi.js as an NPM dependency to lock to a specific commit and not worry about NPM caching while v4 is still in development.