### PR TITLE
Fix actions getting performed when entering and leaving a frame.

### DIFF
--- a/src/animate/Animator.js
+++ b/src/animate/Animator.js
@@ -41,7 +41,7 @@ class Animator {
     }
 
     /**
-     * Play an animation by 
+     * Play an animation by
      * @method play
      * @static
      * @param {PIXI.animate.MovieClip} instance Movie clip to play.
@@ -88,14 +88,18 @@ class Animator {
         this._timelines.push(timeline);
 
         // Set the current frame
-        instance.gotoAndPlay(event);
+        if (instance.currentFrame !== startLabel.position) {
+            instance.gotoAndPlay(event);
+        } else {
+            instance.play();
+        }
         this._refresh();
 
         return timeline;
     }
 
     /**
-     * Stop the animation 
+     * Stop the animation
      * @method stop
      * @static
      * @param {PIXI.animate.MovieClip} instance Movie clip to play.
@@ -111,7 +115,7 @@ class Animator {
     }
 
     /**
-     * Stop the animation 
+     * Stop the animation
      * @method _internalStop
      * @private
      * @static

--- a/src/animate/MovieClip.js
+++ b/src/animate/MovieClip.js
@@ -663,9 +663,7 @@ class MovieClip extends Container {
             return;
         }
         // prevent _updateTimeline from overwriting the new position because of a reset:
-        if (this._prevPos === -1) {
-            this._prevPos = NaN;
-        }
+        this._prevPos = NaN;
         this.currentFrame = pos;
         //update the elapsed time if a time based movieclip
         if (this._framerate > 0) {
@@ -705,8 +703,7 @@ class MovieClip extends Container {
         }
 
         // update timeline position, ignoring actions if this is a graphic.
-        let startFrame = this._prevPos < 0 ? 0 : this._prevPos;
-        this._setTimelinePosition(startFrame, this.currentFrame, synched ? false : this.actionsEnabled);
+        this._setTimelinePosition(this._prevPos, this.currentFrame, synched ? false : this.actionsEnabled);
 
         this._prevPos = this.currentFrame;
     }
@@ -793,7 +790,7 @@ class MovieClip extends Container {
             } else {
                 length = Math.min(currentFrame + 1, actions.length);
             }
-            for (i = startFrame, length = Math.min(currentFrame + 1, actions.length); i < length; ++i) {
+            for (i = startFrame >= 0 ? startFrame + 1 : currentFrame; i < length; ++i) {
                 if (actions[i]) {
                     let frameActions = actions[i];
                     for (j = 0; j < frameActions.length; ++j) {


### PR DESCRIPTION
Fixes #8.
Actions were being doubled up basically all the time, because they were getting performed when entering a frame and leaving it. 
Also stops actions from being doubled up when playing animations from Animator, by not calling both `gotoAndStop()` and `gotoAndPlay()`. As `goto...` performs actions, only `gotoAndStop()` is needed, as it is already on the correct frame when it is time to play.