### PR TITLE
Animator Improvements

### DIFF
--- a/src/animate/Animator.js
+++ b/src/animate/Animator.js
@@ -143,11 +143,14 @@ class Animator {
         // Stop any animation that's playing
         this.stop(instance);
 
+        loop = !!loop;
+
         // Add a new timeline
         const timeline = AnimatorTimeline.create(
             instance,
             start,
-            end, !!loop,
+            end,
+            loop,
             callback
         );
         this._timelines.push(timeline);

--- a/src/animate/Animator.js
+++ b/src/animate/Animator.js
@@ -75,7 +75,7 @@ class Animator {
                 throw new Error("No end label matching '" + label + "'");
             }
         }
-        return this.playFromTo(
+        return this.fromTo(
             instance,
             start,
             end,
@@ -94,7 +94,7 @@ class Animator {
      * @return {PIXI.animate.AnimatorTimeline} Timeline object for stopping or getting progress.
      */
     static to(instance, end, callback) {
-        return this.playFromTo(
+        return this.fromTo(
             instance,
             instance.currentFrame,
             end,

--- a/src/animate/AnimatorTimeline.js
+++ b/src/animate/AnimatorTimeline.js
@@ -60,9 +60,7 @@ class AnimatorTimeline {
             if (this.loop) {
                 instance.gotoAndPlay(this.start);
             } else {
-                // stop on the last frame, in low-framerate
-                // environment, this could settle on the last frame
-                instance.gotoAndStop(this.end);
+                instance.stop();
                 var callback = this.callback;
                 this.stop();
                 if (callback) {

--- a/src/animate/AnimatorTimeline.js
+++ b/src/animate/AnimatorTimeline.js
@@ -58,6 +58,8 @@ class AnimatorTimeline {
             instance.currentFrame = this.end;
 
             if (this.loop) {
+                // Update timeline so we get actions at the end frame
+                instance._updateTimeline();
                 instance.gotoAndPlay(this.start);
             } else {
                 instance.stop();

--- a/src/animate/MovieClip.js
+++ b/src/animate/MovieClip.js
@@ -224,6 +224,14 @@ class MovieClip extends Container {
          */
         this._actions = [];
 
+        /**
+         * Optional callback fired before timeline is updated.
+         * Can be used to clamp or update the currentFrame. 
+         * @property beforeUpdateTimeline
+         * @type {Function}
+         */
+        this.beforeUpdateTimeline = null;
+
         if (this.mode === MovieClip.INDEPENDENT) {
             this._tickListener = this._tickListener.bind(this);
             this._onAdded = this._onAdded.bind(this);
@@ -646,6 +654,9 @@ class MovieClip extends Container {
         //final error checking
         if (this.currentFrame >= this._totalFrames) {
             this.currentFrame = this._totalFrames - 1;
+        }
+        if (this.beforeUpdateTimeline) {
+            this.beforeUpdateTimeline(this);
         }
         //update all tweens & actions in the timeline
         this._updateTimeline();


### PR DESCRIPTION
### Added

* Adds `Animator.stopAll` to stop all the current animation timelines
* Adds `Animator.fromTo(instance, start, end, loop, callback)` as a lower-level version of `play` to allow for different types of label schemas or to use frame numbers.
* Adds `Animator.to(instance, end, callback)` to play to a certain frame and get a callback.
* Adds `Animator.play(instance, callback)` this will play the entire timeline from 0 to the last frame.

### Fixed

* Fixes an issue where Animator would go past the end frame when animating in low performing environments