### PR TITLE
IE9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - "4"
+    - "6"
 
 install:
     - npm install xvfb-maybe

--- a/src/animate/load.js
+++ b/src/animate/load.js
@@ -76,6 +76,11 @@ const load = function(options, parent, complete, basePath) {
         complete: null
     }, options || {});
 
+    const Resource = PIXI.loaders.Resource;
+    Resource.setExtensionLoadType('wav', Resource.LOAD_TYPE.AUDIO);
+    Resource.setExtensionLoadType('mp3', Resource.LOAD_TYPE.AUDIO);
+    Resource.setExtensionLoadType('ogg', Resource.LOAD_TYPE.AUDIO);
+
     const loader = new PIXI.loaders.Loader();
 
     function done() {

--- a/src/animate/load.js
+++ b/src/animate/load.js
@@ -6,6 +6,7 @@
  * @param {Object} [options.stage.assets] Assets used to preload
  * @param {PIXI.Container} options.parent The Container to auto-add the stage to.
  * @param {String} [options.basePath] Base root directory
+ * @return {PIXI.loaders.Loader} instance of PIXI resource loader
  */
 /**
  * Load the stage class and preload any assets
@@ -25,6 +26,7 @@
  * @param {Function} StageRef Reference to the stage class.
  * @param {Object} [StageRef.assets] Assets used to preload.
  * @param {Function} complete The callback function when complete.
+ * @return {PIXI.loaders.Loader} instance of PIXI resource loader
  */
 /**
  * Load the stage class and preload any assets
@@ -42,6 +44,7 @@
  * @param {Function} StageRef Reference to the stage class.
  * @param {Object} [StageRef.assets] Assets used to preload.
  * @param {PIXI.Container} parent The Container to auto-add the stage to.
+ * @return {PIXI.loaders.Loader} instance of PIXI resource loader
  */
 const load = function(options, parent, complete, basePath) {
 
@@ -81,7 +84,7 @@ const load = function(options, parent, complete, basePath) {
             options.parent.addChild(instance);
         }
         if (options.complete) {
-            options.complete(instance);
+            options.complete(instance, loader);
         }
     }
 
@@ -101,6 +104,8 @@ const load = function(options, parent, complete, basePath) {
         // tiny case where there's only text and no shapes/animations
         done();
     }
+
+    return loader;
 };
 
 export default load;

--- a/tasks/common/bundler.js
+++ b/tasks/common/bundler.js
@@ -23,7 +23,7 @@ module.exports = function(gulp, options, plugins, debug) {
 
         let stream = bundler
             .transform(plugins.babelify.configure({
-                presets: ['es2015'],
+                presets: [ ['es2015', {loose: true}] ],
                 sourceMaps: true
             }))
             .bundle()


### PR DESCRIPTION
Fixes #17 by running the Babel es2015 preset in 'loose' mode.

Have tested in IE9 and can confirm that everything seems to work after this fix. 