### PR TITLE
Create new sound emitter and playSound function

### DIFF
--- a/src/animate/MovieClip.js
+++ b/src/animate/MovieClip.js
@@ -240,7 +240,7 @@ class MovieClip extends Container {
 
         /**
          * Optional callback fired before timeline is updated.
-         * Can be used to clamp or update the currentFrame. 
+         * Can be used to clamp or update the currentFrame.
          * @name PIXI.animate.MovieClip#_beforeUpdate
          * @type {Function}
          * @private
@@ -616,6 +616,32 @@ class MovieClip extends Container {
         } else {
             actions[startFrame] = [callback];
         }
+        return this;
+    }
+
+    /**
+     * Short cut for `playSound`
+     * @method PIXI.animate.MovieClip#ps
+     * @param {String} alias The name of the Sound
+     * @param {Boolean} loop The loop property of the sound
+     * @param {MovieClip} context The MovieClip the sound originates from
+     * @return {PIXI.animate.MovieClip}
+     */
+    ps(alias, loop, context) {
+        return this.playSound(alias, loop, context);
+    }
+
+    /**
+     * Handle sounds.
+     * @method PIXI.animate.MovieClip#playSound
+     * @param {String} alias The name of the Sound
+     * @param {Boolean} loop The loop property of the sound
+     * @param {MovieClip} context The MovieClip the sound originates from
+     * @return {PIXI.animate.MovieClip}
+     */
+    playSound(alias, loop, context) {
+        console.log('playSound', alias, loop, context);
+        PIXI.animate.sound.emit('play', alias, loop, context);
         return this;
     }
 

--- a/src/animate/MovieClip.js
+++ b/src/animate/MovieClip.js
@@ -627,8 +627,8 @@ class MovieClip extends Container {
      * @param {MovieClip} context The MovieClip the sound originates from
      * @return {PIXI.animate.MovieClip}
      */
-    ps(alias, loop, context) {
-        return this.playSound(alias, loop, context);
+    ps(alias, loop) {
+        return this.playSound(alias, loop);
     }
 
     /**
@@ -639,9 +639,8 @@ class MovieClip extends Container {
      * @param {MovieClip} context The MovieClip the sound originates from
      * @return {PIXI.animate.MovieClip}
      */
-    playSound(alias, loop, context) {
-        console.log('playSound', alias, loop, context);
-        PIXI.animate.sound.emit('play', alias, loop, context);
+    playSound(alias, loop) {
+        PIXI.animate.sound.emit('play', alias, loop, this);
         return this;
     }
 

--- a/src/animate/index.js
+++ b/src/animate/index.js
@@ -1,4 +1,5 @@
 import load from './load';
+import sound from './sound';
 import utils from './utils';
 import MovieClip from './MovieClip';
 import ShapesCache from './ShapesCache';
@@ -15,6 +16,7 @@ export default {
     Animator,
     AnimatorTimeline,
     load,
+    sound,
     utils,
     MovieClip,
     ShapesCache,

--- a/src/animate/load.js
+++ b/src/animate/load.js
@@ -82,11 +82,6 @@ const load = function(options, parent, complete, basePath) {
         complete: null
     }, options || {});
 
-    const Resource = PIXI.loaders.Resource;
-    Resource.setExtensionLoadType('wav', Resource.LOAD_TYPE.AUDIO);
-    Resource.setExtensionLoadType('mp3', Resource.LOAD_TYPE.AUDIO);
-    Resource.setExtensionLoadType('ogg', Resource.LOAD_TYPE.AUDIO);
-
     const loader = new PIXI.loaders.Loader();
 
     function done() {

--- a/src/animate/sound.js
+++ b/src/animate/sound.js
@@ -1,0 +1,1 @@
+export default new PIXI.utils.EventEmitter();


### PR DESCRIPTION
This adds the `playSound` method to `PIXI.animate.MovieClip` as discussed in the [pixi-animate-extension pr](https://github.com/jiborobot/pixi-animate-extension/pull/19).

I was working with these changes in my project for a couple days last week and I feel like it does the job pretty well.