### PR TITLE
Fix to setMask to retain object chaining on warning.

### DIFF
--- a/src/mixins/DisplayObject.js
+++ b/src/mixins/DisplayObject.js
@@ -66,7 +66,7 @@ p.setMask = p.ma = function(mask) {
             if (typeof console !== "undefined" && console.warn) {
                 console.warn("Warning: Masks can only be PIXI.Graphics or PIXI.Sprite objects.");
             }
-            return;
+            return this;
         }
     }
     this.mask = mask;


### PR DESCRIPTION
Currently the mask warning can indirectly break later `DisplayObject` references due to its return being `undefined`. This fix allows the object to be referenced in chaining and variable assignments even when the mask is not applied.