### PR TITLE
Text align left should be set to -1

### DIFF
--- a/src/mixins/Text.js
+++ b/src/mixins/Text.js
@@ -6,7 +6,7 @@
 const p = PIXI.Text.prototype;
 
 // Possible align values
-const ALIGN_VALUES = ["center", "right", "left"];
+const ALIGN_VALUES = ["center", "right"];
 
 /**
  * Setter for the alignment, also sets the anchor point


### PR DESCRIPTION
Sorry @bigtimebuddy, just spotted a small problem with my last PR in that with non-compressed output align 'left' would be set to '2' for the anchoring, rather than the expected '-1'.