### PR TITLE
Better module typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PIXI Animate
 
-A plugin for Pixi.js which provides a runtime for content export using PixiAnimate Extension. 
+A plugin for Pixi.js which provides a runtime for content export using PixiAnimate Extension.
 
 [![Build Status](https://travis-ci.org/jiborobot/pixi-animate.svg?branch=master)](https://travis-ci.org/jiborobot/pixi-animate) [![Dependency Status](https://david-dm.org/jiborobot/pixi-animate.svg)](https://david-dm.org/jiborobot/pixi-animate) [![npm version](https://badge.fury.io/js/pixi-animate.svg)](https://badge.fury.io/js/pixi-animate)
 
@@ -22,6 +22,23 @@ npm install pixi-animate
 ## Documentation
 
 http://jiborobot.github.io/pixi-animate/
+
+## Typescript
+You can use require to get the namespace for PixiAnimate, or use a triple slash reference for using the PIXI.animate namespace.
+```typescript
+// Note: Must also include the pixi.js typings globally!
+import animate = require('pixi-animate');
+
+let myMC:animate.MovieClip = new animate.MovieClip();
+```
+
+```typescript
+// Note: Must also include the pixi.js typings globally!
+/// <reference path="node_modules/pixi-animate/ambient.d.ts" />
+require('pixi-animate');
+
+let myMC:PIXI.animate.MovieClip = new PIXI.animate.MovieClip();
+```
 
 ## License
 

--- a/ambient.d.ts
+++ b/ambient.d.ts
@@ -1,5 +1,5 @@
 // Typings for PixiAnimate 1.0.0, requires Pixi.js typings
-declare namespace animate {
+declare namespace PIXI.animate {
 
     export namespace utils {
         export function hexToUint(hex:string|number):number;
@@ -143,4 +143,6 @@ declare namespace animate {
     }
 }
 
-export = animate;
+declare module 'pixi-animate' {
+    export = PIXI.animate;
+}

--- a/ambient.d.ts
+++ b/ambient.d.ts
@@ -21,7 +21,8 @@ declare namespace PIXI.animate {
 
     type LoadCallback = (instance:MovieClip) => void;
 
-    export function load(StageRef:any, parent:PIXI.Container):PIXI.loaders.Loader;
+    export function load(StageRef:any, parent:PIXI.Container, callback?:LoadCallback, basePath?:string):PIXI.loaders.Loader;
+    export function load(StageRef:any, parent:PIXI.Container, basePath?:string):PIXI.loaders.Loader;
     export function load(StageRef:any, callback:LoadCallback):PIXI.loaders.Loader;
     export function load(options:LoadOptions):PIXI.loaders.Loader;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,8 @@ declare namespace animate {
 
     type LoadCallback = (instance:MovieClip) => void;
 
-    export function load(StageRef:any, parent:PIXI.Container):PIXI.loaders.Loader;
+    export function load(StageRef:any, parent:PIXI.Container, callback?:LoadCallback, basePath?:string):PIXI.loaders.Loader;
+    export function load(StageRef:any, parent:PIXI.Container, basePath?:string):PIXI.loaders.Loader;
     export function load(StageRef:any, callback:LoadCallback):PIXI.loaders.Loader;
     export function load(options:LoadOptions):PIXI.loaders.Loader;
 

--- a/src/animate/load.js
+++ b/src/animate/load.js
@@ -50,6 +50,27 @@ Resource.setExtensionLoadType('ogg', Resource.LOAD_TYPE.AUDIO);
  * @param {Function} StageRef Reference to the stage class.
  * @param {Object} [StageRef.assets] Assets used to preload.
  * @param {PIXI.Container} parent The Container to auto-add the stage to.
+ * @param {String} [basePath] Base root directory
+ * @return {PIXI.loaders.Loader} instance of PIXI resource loader
+ */
+/**
+ * Load the stage class and preload any assets
+ * ```
+ * let renderer = new PIXI.autoDetectRenderer(1280, 720);
+ * let stage = new PIXI.Container();
+ * PIXI.animate.load(lib.MyStage, stage);
+ * function update() {
+ *      renderer.render(stage);
+ *      update();
+ * }
+ * update();
+ * ```
+ * @method PIXI.animate.load
+ * @param {Function} StageRef Reference to the stage class.
+ * @param {Object} [StageRef.assets] Assets used to preload.
+ * @param {PIXI.Container} parent The Container to auto-add the stage to.
+ * @param {Function} [complete] The callback function when complete.
+ * @param {String} [basePath] Base root directory
  * @return {PIXI.loaders.Loader} instance of PIXI resource loader
  */
 const load = function(options, parent, complete, basePath) {


### PR DESCRIPTION
Changed typings included via `require()` to be a module typing, kept previous file as global typing for optional inclusion in place of the module typing.