### PR TITLE
Added an overload for Animator.play() to d.ts files

### DIFF
--- a/ambient.d.ts
+++ b/ambient.d.ts
@@ -125,6 +125,7 @@ declare namespace PIXI.animate {
     export class Animator {
         static STOP_LABEL:string;
         static LOOP_LABEL:string;
+        static play(instance:MovieClip, callback?:Function):AnimatorTimeline;
         static play(instance:MovieClip, label:string, callback?:Function):AnimatorTimeline;
         static to(instance:MovieClip, end:string|number, callback?:Function):AnimatorTimeline;
         static fromTo(instance:MovieClip, start:string|number, end:string|number, loop?:boolean, callback?:Function):AnimatorTimeline;

--- a/index.d.ts
+++ b/index.d.ts
@@ -125,6 +125,7 @@ declare namespace animate {
     export class Animator {
         static STOP_LABEL:string;
         static LOOP_LABEL:string;
+        static play(instance:MovieClip, callback?:Function):AnimatorTimeline;
         static play(instance:MovieClip, label:string, callback?:Function):AnimatorTimeline;
         static to(instance:MovieClip, end:string|number, callback?:Function):AnimatorTimeline;
         static fromTo(instance:MovieClip, start:string|number, end:string|number, loop?:boolean, callback?:Function):AnimatorTimeline;


### PR DESCRIPTION
Added an overload for Animator.play() to .d.ts files, for the `Animator.play(clip, callback)` form.