### PR TITLE
Add a new Scene API for easier construction

### DIFF
--- a/ambient.d.ts
+++ b/ambient.d.ts
@@ -42,6 +42,12 @@ declare namespace PIXI.animate {
         framerate?:number;
     }
 
+    export class Scene extends PIXI.Application {
+        constructor(width?:number, height?:number, renderOptions?:any, noWebGL?:boolean);
+        public sound:PIXI.utils.EventEmitter;
+        public load(StageRef:any, callback?:LoadCallback, basePath?:string):PIXI.loaders.Loader;
+    }
+
     export class MovieClip extends PIXI.DisplayObject {
         public mode:number;
         public startPosition:number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,6 +42,12 @@ declare namespace animate {
         framerate?:number;
     }
 
+    export class Scene extends PIXI.Application {
+        constructor(width?:number, height?:number, renderOptions?:any, noWebGL?:boolean);
+        public sound:PIXI.utils.EventEmitter;
+        public load(StageRef:any, callback?:LoadCallback, basePath?:string):PIXI.loaders.Loader;
+    }
+
     export class MovieClip extends PIXI.DisplayObject {
         public mode:number;
         public startPosition:number;

--- a/src/animate/Scene.js
+++ b/src/animate/Scene.js
@@ -2,7 +2,7 @@ import load from './load';
 import sound from './sound';
 
 /**
- * Extends the PIXI.Application to provide easy loading.
+ * Extends the PIXI.Application class to provide easy loading.
  * ```
  * const scene = new PIXI.animate.Scene();
  * scene.load(lib.StageName);
@@ -40,8 +40,8 @@ class Scene extends PIXI.Application {
 	 * Load a stage scene and add it to the stage.
 	 * @method PIXI.animate.Scene#load
 	 * @param {Function} StageRef Reference to the stage class.
-	 * @param {Function} [complete]
-	 * @param {String} [basePath] Base root directory
+	 * @param {Function} [complete] Callback when finished loading.
+	 * @param {String} [basePath] Optional base directory to prepend to assets.
 	 * @return {PIXI.loaders.Loader} instance of PIXI resource loader
 	 */
 	load(StageRef, complete, basePath) {

--- a/src/animate/Scene.js
+++ b/src/animate/Scene.js
@@ -1,0 +1,44 @@
+import load from './load';
+import sound from './sound';
+
+/**
+ * Extends the PIXI.Application to provide easy loading.
+ * ```
+ * const scene = new PIXI.animate.Scene();
+ * scene.load(lib.StageName);
+ * ```
+ * @class Scene
+ * @memberof PIXI.animate
+ * @param {Number} [width=800] Stage width
+ * @param {Number} [height=600] Stage height
+ * @param {Object} [renderOptions] See PIXI.Application for more info.
+ * @param {Boolean} [noWebGL=false] Disable WebGL
+ */
+class Scene extends PIXI.Application {
+
+	constructor(width, height, renderOptions, noWebGL) {
+		super(width, height, renderOptions, noWebGL);
+
+		/**
+		 * Reference to the global sound object
+		 * @name PIXI.animate.Scene#sound
+		 * @type {PIXI.animate.sound}
+		 * @readOnly
+		 */
+		this.sound = sound;
+	}
+
+	/**
+	 * Load a stage scene and add it to the stage.
+	 * @method PIXI.animate.Scene#load
+	 * @param {Function} StageRef Reference to the stage class.
+	 * @param {Function} [complete]
+	 * @param {String} [basePath] Base root directory
+	 * @return {PIXI.loaders.Loader} instance of PIXI resource loader
+	 */
+	load(StageRef, complete, basePath) {
+		return load(StageRef, this.stage, complete, basePath);
+	}
+}
+
+export default Scene;

--- a/src/animate/Scene.js
+++ b/src/animate/Scene.js
@@ -56,13 +56,14 @@ class Scene extends PIXI.Application {
 	/**
 	 * Destroy and don't use after calling.
 	 * @method PIXI.animate.Scene#destroy
+	 * @param {Boolean} [removeView=false] `true` to remove canvas element.
 	 */
-	destroy() {
+	destroy(removeView) {
 		if (this.instance) {
 			this.instance.destroy(true);
 			this.instance = null;
 		}
-		super.destroy();
+		super.destroy(removeView);
 	}
 }
 

--- a/src/animate/Scene.js
+++ b/src/animate/Scene.js
@@ -26,6 +26,14 @@ class Scene extends PIXI.Application {
 		 * @readOnly
 		 */
 		this.sound = sound;
+
+		/**
+		 * The stage object created.
+		 * @name PIXI.animate.Scene#instance
+		 * @type {PIXI.animate.MovieClip}
+		 * @readOnly
+		 */
+		this.instance = null;
 	}
 
 	/**
@@ -37,7 +45,24 @@ class Scene extends PIXI.Application {
 	 * @return {PIXI.loaders.Loader} instance of PIXI resource loader
 	 */
 	load(StageRef, complete, basePath) {
-		return load(StageRef, this.stage, complete, basePath);
+		return load(StageRef, this.stage, (instance) => {
+			this.instance = instance;
+			if (complete) {
+				complete(instance);
+			}
+		}, basePath);
+	}
+
+	/**
+	 * Destroy and don't use after calling.
+	 * @method PIXI.animate.Scene#destroy
+	 */
+	destroy() {
+		if (this.instance) {
+			this.instance.destroy(true);
+			this.instance = null;
+		}
+		super.destroy();
 	}
 }
 

--- a/src/animate/index.js
+++ b/src/animate/index.js
@@ -2,6 +2,7 @@ import load from './load';
 import sound from './sound';
 import utils from './utils';
 import MovieClip from './MovieClip';
+import Scene from './Scene';
 import ShapesCache from './ShapesCache';
 import SymbolLoader from './SymbolLoader';
 import Timeline from './Timeline';
@@ -21,6 +22,7 @@ export {
     sound,
     utils,
     MovieClip,
+    Scene,
     ShapesCache,
     SymbolLoader,
     Timeline,


### PR DESCRIPTION
Creates a new Scene object which extends the brand new `PIXI.Application` API to create for much simpler setup code.

Requires unreleased version of PIXI: v4.3.3