### PR TITLE
Fixed bug that frame action may be miss

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "k8w-pixi-animate",
   "description": "PIXI plugin for the PixiAnimate Extension (k8w modified)",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "lib/index.js",
   "author": "k8w <me@k8w.io>",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "k8w-pixi-animate",
   "description": "PIXI plugin for the PixiAnimate Extension (k8w modified)",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "lib/index.js",
   "author": "k8w <me@k8w.io>",
   "devDependencies": {
@@ -54,8 +54,7 @@
     "postversion": "npm run build && npm test",
     "publish:patch": "npm version patch && npm publish",
     "publish:minor": "npm version minor && npm publish",
-    "publish:major": "npm version major && npm publish",
-    "postpublish": "git push && git push --tags && npm run docs-live"
+    "publish:major": "npm version major && npm publish"
   },
   "files": [
     "dist/",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "pixi-animate",
-  "description": "PIXI plugin for the PixiAnimate Extension",
-  "version": "1.3.2",
+  "name": "k8w-pixi-animate",
+  "description": "PIXI plugin for the PixiAnimate Extension (k8w modified)",
+  "version": "1.4.0",
   "main": "lib/index.js",
-  "author": "Matt Karl <matt.karl@jibo.com>",
+  "author": "k8w <me@k8w.io>",
   "devDependencies": {
     "babel-cli": "^6.22.2",
     "babel-plugin-version-inline": "^1.0.0",
@@ -27,12 +27,12 @@
   "typings": "index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jiborobot/pixi-animate"
+    "url": "https://github.com/k8w/pixi-animate"
   },
   "bugs": {
-    "url": "https://github.com/jiborobot/pixi-animate/issues"
+    "url": "https://github.com/k8w/pixi-animate/issues"
   },
-  "homepage": "https://github.com/jiborobot/pixi-animate",
+  "homepage": "https://github.com/k8w/pixi-animate",
   "scripts": {
     "clean": "rimraf docs coverage dist/** lib/** .publish",
     "lint": "eslint src tests",

--- a/src/animate/MovieClip.js
+++ b/src/animate/MovieClip.js
@@ -807,6 +807,25 @@ class MovieClip extends Container {
     }
 
     /**
+     * Execute actions from `startFrame` to `endFrame`
+     * @method PIXI.animate.MovieClip#_doActions
+     * @protected
+     * @param {int} startFrame 
+     * @param {int} endFrame 
+     */
+    _doActions(startFrame, endFrame) {
+        const actions = this._actions;
+        for (let i = startFrame; i <= endFrame; ++i) {
+            if (actions[i]) {
+                let frameActions = actions[i];
+                for (let j = 0; j < frameActions.length; ++j) {
+                    frameActions[j].call(this);
+                }
+            }
+        }
+    }
+
+    /**
      * Set the timeline position
      * @method PIXI.animate.MovieClip#_setTimelinePosition
      * @protected
@@ -879,29 +898,16 @@ class MovieClip extends Container {
 
         //handle actions
         if (doActions) {
-            let actions = this._actions;
             //if start frame == -1, it infers that this haven't been played, jump to currentFrame directly
             let startPos = startFrame > -1 ? startFrame + 1 : currentFrame;
-
-            const loopActions = (start, end) => {
-                for (let i = start; i <= end; ++i) {
-                    if (actions[i]) {
-                        let frameActions = actions[i];
-                        for (let j = 0; j < frameActions.length; ++j) {
-                            frameActions[j].call(this);
-                        }
-                    }
-                }
-            }
-
             //Need loop
             if (currentFrame < startPos) {
-                loopActions(startPos, actions.length - 1);
-                loopActions(0, currentFrame);
+                this._doActions(startPos, this._actions.length - 1);
+                this._doActions(0, currentFrame);
             }
             //No need loop
             else {
-                loopActions(startPos, currentFrame)
+                this._doActions(startPos, currentFrame)
             }
         }
     }

--- a/src/animate/MovieClip.js
+++ b/src/animate/MovieClip.js
@@ -895,7 +895,7 @@ class MovieClip extends Container {
             }
 
             //Need loop
-            if (currentFrame < startFrame) {
+            if (currentFrame < startPos) {
                 loopActions(startPos, actions.length - 1);
                 loopActions(0, currentFrame);
             }

--- a/src/animate/MovieClip.js
+++ b/src/animate/MovieClip.js
@@ -880,27 +880,28 @@ class MovieClip extends Container {
         //handle actions
         if (doActions) {
             let actions = this._actions;
-            //handle looping around
-            let needsLoop = false;
-            if (currentFrame < startFrame) {
-                length = actions.length;
-                needsLoop = true;
-            } else {
-                length = Math.min(currentFrame + 1, actions.length);
-            }
-            for (i = startFrame >= 0 ? startFrame + 1 : currentFrame; i < length; ++i) {
-                if (actions[i]) {
-                    let frameActions = actions[i];
-                    for (j = 0; j < frameActions.length; ++j) {
-                        frameActions[j].call(this);
+            //if start frame == -1, it infers that this haven't been played, jump to currentFrame directly
+            let startPos = startFrame > -1 ? startFrame + 1 : currentFrame;
+
+            const loopActions = (start, end) => {
+                for (let i = start; i <= end; ++i) {
+                    if (actions[i]) {
+                        let frameActions = actions[i];
+                        for (let j = 0; j < frameActions.length; ++j) {
+                            frameActions[j].call(this);
+                        }
                     }
                 }
-                //handle looping around
-                if (needsLoop && i === length - 1) {
-                    i = 0;
-                    length = currentFrame + 1;
-                    needsLoop = false;
-                }
+            }
+
+            //Need loop
+            if (currentFrame < startFrame) {
+                loopActions(startPos, actions.length - 1);
+                loopActions(0, currentFrame);
+            }
+            //No need loop
+            else {
+                loopActions(startPos, currentFrame)
             }
         }
     }

--- a/src/animate/MovieClip.js
+++ b/src/animate/MovieClip.js
@@ -721,7 +721,7 @@ class MovieClip extends Container {
             this._t += time;
         }
         if (this._t > this._duration) {
-            this._t = this.loop ? this._t - this._duration : this._duration;
+            this._t = this.loop ? this._t % this._duration : this._duration;
         }
         //add a tiny amount to account for potential floating point errors
         this.currentFrame = Math.floor(this._t * this._framerate + 0.00000001);

--- a/src/animate/SymbolLoader.js
+++ b/src/animate/SymbolLoader.js
@@ -19,7 +19,7 @@ let SymbolLoader = function() {
         } else if (data.nodeName && data.nodeName === 'IMG') {
             // Add individual images to the texture cache by their
             // short symbol name, not the URL
-            PIXI.Texture.addTextureToCache(
+            PIXI.Texture.addToCache(
                 PIXI.Texture.fromFrame(url),
                 resource.name
             );


### PR DESCRIPTION
Relative to https://github.com/jiborobot/pixi-animate/issues/67

Modified the flow of _setTimelinePosition:

1. If is crossthrough many frames, generate action frame on the way.
2. Do each action on the way, until `_goto` or `stop` is called.